### PR TITLE
Correct errors handling cookie sessions

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,9 @@ module LaptopStationBackend
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.session_store :cookie_store, key: '_interslice_session'
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use config.session_store, config.session_options
   end
 end


### PR DESCRIPTION
# Hi good reviewer,
## This Pull Request proposes the following changes: 
### Update config/appication.rb to handle cookie sessions.
```
    config.session_store :cookie_store, key: '_interslice_session'
    config.middleware.use ActionDispatch::Cookies
    config.middleware.use config.session_store, config.session_options
  end
end
```